### PR TITLE
Protect src dataset instead of dst dataset

### DIFF
--- a/METADATA-CRAWLER/config/create_overview.sh
+++ b/METADATA-CRAWLER/config/create_overview.sh
@@ -1,4 +1,4 @@
 echo "Creating overview for $1 (layer $2) ..."
-gdal_rasterize -ts $5 $6 -ot Byte -burn 111 -l $2 $1 "$3"
+gdal_rasterize -ts $5 $6 -ot Byte -burn 111 -l $2 "$1" "$3"
 gdal_translate -a_nodata 0 -of PNG -outsize $5 $6 -b 1 "$3" "$4"
 echo "Done."


### PR DESCRIPTION
dst dataset is a local GTif file so it doesn't need to be protected  by double
quote. However, src dataset is usually a PostGIS database and the database
connection string should be protected.

Fix #39